### PR TITLE
Fix to move's destination index path exists in other updates 

### DIFF
--- a/Sourcing/FetchedResultsDataProvider.swift
+++ b/Sourcing/FetchedResultsDataProvider.swift
@@ -102,7 +102,6 @@ open class FetchedResultsDataProvider<Object: NSFetchRequestResult>: NSObject, N
     }
     
     public func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        // Check if destination indexpath in move exists in other updates
         let updatesIndexPaths = updates.flatMap { update -> IndexPath? in
             switch update {
             case .delete(let indexPath), .insert(let indexPath), .update(let indexPath, _):
@@ -110,7 +109,6 @@ open class FetchedResultsDataProvider<Object: NSFetchRequestResult>: NSObject, N
             default: return nil
             }
         }
-        // Do not pass move if destination index paths aleady exists
         let checkedUpdates = updates.flatMap { update-> DataProviderUpdate<Object>? in
             if case .move(_, let newIndexPath) = update, updatesIndexPaths.contains(newIndexPath) {
                return nil

--- a/Sourcing/TableViewDataSource.swift
+++ b/Sourcing/TableViewDataSource.swift
@@ -79,9 +79,16 @@ final public class TableViewDataSource<Object>: NSObject, UITableViewDataSource,
         guard let updates = updates else {
             return tableView.reloadData()
         }
-        tableView.beginUpdates()
-        updates.forEach(process)
-        tableView.endUpdates()
+        if #available(iOSApplicationExtension 11.0, *) {
+            tableView.performBatchUpdates ({
+                updates.forEach(process)
+            }, completion: nil)
+        } else {
+            // Fallback on earlier versions
+            tableView.beginUpdates()
+            updates.forEach(process)
+            tableView.endUpdates()
+        }
     }
     
     public var selectedObject: Object? {


### PR DESCRIPTION
Review required for proposed fix:
When there are multiple updates and has move, and move's destinationIndexPath exists in other updates Core Data will throw following error:

> CoreData: error: Serious application error.  An exception was caught from the delegate of NSFetchedResultsController during a call to -controllerDidChangeContent:.  attempt to perform an insert and a move to the same index path (<NSIndexPath: 0xc000000000000016> {length = 2, path = 0 - 0}) with userInfo (null)

Proposed fix:
1. Get all indexpaths in updates (except move)
2. Check if there are moves in updates and destinationIndexPath already in use, if yes return nil

Please suggest any refactoring.

Also done some spelling correction and small refactoring.